### PR TITLE
Fix: 'NoneType' object is not iterable

### DIFF
--- a/tasks/analyze.yml
+++ b/tasks/analyze.yml
@@ -18,7 +18,7 @@
 
     - name: analyze - Process analyze
       set_fact:
-        log4shell_analyze_versions: "{{ log4shell_analyze_versions|default({}) | combine({item.item: ((item.files | map('regex_search', _log4shell_regex, '\\1') | select('iterable') | map('first') | list | first) if item.item.endswith('.war') else item.item | regex_search(_log4shell_regex, '\\1') | first )}) }}"
+        log4shell_analyze_versions: "{{ log4shell_analyze_versions|default({}) | combine({item.item: ((item.files | map('regex_search', _log4shell_regex, '\\1') | select('iterable') | map('first') | list | first) if item.item.endswith('.war') else item.item | regex_search(_log4shell_regex, '\\1') | default([_log4shell_dummy_version], true) | first )}) }}"
       loop: "{{ _log4shell_analyze_unarchive.results|default([]) }}"
       loop_control:
         label: "{{ item.item }}"
@@ -27,7 +27,7 @@
         - name: analyze - Check for CVE-2021-44228 (Log4Shell)
           assert:
             that:
-              - item.value is version(_log4shell_patched_version, '>=')
+              - item.value is version(_log4shell_patched_version, '>=') or item.value is version(_log4shell_dummy_version, '==')
             fail_msg: "{{ item.key }} is using Log4J version {{ item.value }} which may be **VULNERABLE** to CVE-2021-44228 (Log4Shell)"
             success_msg: "{{ item.key }} is using Log4J version {{ item.value }} which is **NOT** vulnerable to CVE-2021-44228 (Log4Shell)"
           loop: "{{ log4shell_analyze_versions | dict2items }}"

--- a/tasks/analyze.yml
+++ b/tasks/analyze.yml
@@ -18,7 +18,7 @@
 
     - name: analyze - Process analyze
       set_fact:
-        log4shell_analyze_versions: "{{ log4shell_analyze_versions|default({}) | combine({item.item: ((item.files | map('regex_search', _log4shell_regex, '\\1') | select('iterable') | map('first') | list | first) if item.item.endswith('.war') else item.item | regex_search(_log4shell_regex, '\\1') | default([_log4shell_dummy_version], true) | first )}) }}"
+        log4shell_analyze_versions: "{{ log4shell_analyze_versions|default({}) | combine({item.item: ((item.files | map('regex_search', _log4shell_regex, '\\1') | default([_log4shell_dummy_version], true) | select('iterable') | map('first') | list | first) if item.item.endswith('.war') else item.item | regex_search(_log4shell_regex, '\\1') | default([_log4shell_dummy_version], true) | first )}) }}"
       loop: "{{ _log4shell_analyze_unarchive.results|default([]) }}"
       loop_control:
         label: "{{ item.item }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,5 @@
 ---
 _log4shell_regex: 'log4j-core\S+(\d+.\d+.\d+)\S*\.jar'
 _log4shell_patched_version: '2.14.1'
+_log4shell_dummy_version: '0.0.0'
 ...


### PR DESCRIPTION
TASK [claranet.log4shell : analyze - Process analyze]
**************************

fatal: [srv00192]: FAILED! => {"msg": "Unexpected templating type error
occurred on ({{ log4shell_analyze_versions|default({}) |
combine({item.item: ((item.files | map('regex_search', _log4shell_regex,
'\\\\1') | select('iterable') | map('first') | list | first) if
item.item.endswith('.war') else item.item |
regex_search(_log4shell_regex, '\\\\1') | first )}) }}): 'NoneType'
object is not iterable"}

<!--- Provide a general summary of your changes in the Title above -->

## Description
On jar files, when regex returns None, we can't select first item of an iterable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Using j2cli (`pip install 'j2cli[yaml]'`),
with this jinja2 template (test.j2):
```
{{ '/usr/share/java/libintl.jar' | regex_search(_log4shell_regex, '\\1') | default([_log4shell_dummy_version], true) | first }}
```
vars file `vars/main.yml`,
and ansible filters.

Using the command:
```
j2 test.j2 vars/main.yml --filters ~/virtualenvs/ansible/venv_4_2_0/lib/python3.7/site-packages/ansible/plugins/filter/core.py
```

I also tested with real remote servers having no vulnerabilities.


My environment is:
```
(venv_4_2_0) rsi-oxalide k8s:rsi-sandbox  :: github.com/claranet/ansible-role-log4shell ‹rsi/fix-nonetype-object-not-iterable*› » pip --version
pip 21.3.1 from /home/rsicart/virtualenvs/ansible/venv_4_2_0/lib/python3.7/site-packages/pip (python 3.7)

(venv_4_2_0) rsi-oxalide k8s:rsi-sandbox  :: github.com/claranet/ansible-role-log4shell ‹rsi/fix-nonetype-object-not-iterable*› » ansible --version
[DEPRECATION WARNING]: Ansible will require Python 3.8 or newer on the controller starting with Ansible 2.12. Current version: 3.7.3 (default, Jan 22 2021, 20:04:44) [GCC 8.3.0]. This feature will be removed 
from ansible-core in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
ansible [core 2.11.6] 
  config file = None
  configured module search path = ['/home/rsicart/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/rsicart/virtualenvs/ansible/venv_4_2_0/lib/python3.7/site-packages/ansible
  ansible collection location = /home/rsicart/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/rsicart/virtualenvs/ansible/venv_4_2_0/bin/ansible
  python version = 3.7.3 (default, Jan 22 2021, 20:04:44) [GCC 8.3.0]
  jinja version = 3.0.3
  libyaml = True
```

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
